### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # 🔭 Neo gitmoji
 
-A Telescope integration for [gitmoji](https://github.com/).
+A Telescope integration for [gitmoji](https://gitmoji.dev/).
 
 ## Installation
 


### PR DESCRIPTION
gitmoji has its own page, so it should be better than github.com.