### PR TITLE
✨ accept character backtick to `highlight` word in commit message

### DIFF
--- a/lua/neo-gitmoji/git-commands.lua
+++ b/lua/neo-gitmoji/git-commands.lua
@@ -1,5 +1,8 @@
 local Git = {}
 
-function Git.commit(title) vim.cmd(string.format('!git commit -m "%s"', title)) end
+function Git.commit(title)
+  local clean_title = title:gsub("`", "\\`")
+  vim.cmd(string.format('!git commit -m "%s"', clean_title))
+end
 
 return Git

--- a/lua/neo-gitmoji/git-commands.lua
+++ b/lua/neo-gitmoji/git-commands.lua
@@ -1,8 +1,11 @@
 local Git = {}
 
+function format_title(title)
+  return title:gsub("`", "\\`")
+end
+
 function Git.commit(title)
-  local clean_title = title:gsub("`", "\\`")
-  vim.cmd(string.format('!git commit -m "%s"', clean_title))
+  vim.cmd(string.format('!git commit -m "%s"', format_title(title)))
 end
 
 return Git


### PR DESCRIPTION
# Feature
- Escape backtick to allow highlight word in commit message
- Move this logic to a function called format_titel